### PR TITLE
Fix/admin community header

### DIFF
--- a/src/lib/components/communities/CommunityHeader.svelte
+++ b/src/lib/components/communities/CommunityHeader.svelte
@@ -1,0 +1,36 @@
+<script>
+	import Time from 'svelte-time/Time.svelte';
+	import StateBadge from '../common/StateBadge.svelte';
+	import CommunityActions from '../../../routes/(detail)/community/[uid]/CommunityActions.svelte';
+	import { useGetAdminCommunity } from '$lib/hooks/communities';
+
+	export let isAdmin = false;
+	export let title = '';
+	export let description = '';
+	export let state = {};
+	export let uid;
+
+	let community = useGetAdminCommunity(uid);
+	$: cmn = $community.data;
+</script>
+
+<div class="flex items-center justify-between">
+	<div>
+		<StateBadge data={state} />
+		<span class="ms-2 text-xs">
+			Last update <Time relative={true} timestamp={$community.data?.createdUTC.replace('T', ' ')} />
+		</span>
+	</div>
+</div>
+{#if !isAdmin}
+	<div class="float-right">
+		<CommunityActions community={cmn} />
+	</div>
+{/if}
+<h6 class="mb-2 mt-2 pt-1 text-3xl font-bold text-gray-900 dark:text-white">
+	{title}
+</h6>
+<p class="mb-2 text-base text-gray-600 dark:text-gray-400">
+	{description}
+</p>
+&nbsp;

--- a/src/lib/components/communities/CommunityHeader.svelte
+++ b/src/lib/components/communities/CommunityHeader.svelte
@@ -1,14 +1,14 @@
-<script>
+<script lang="ts">
 	import Time from 'svelte-time/Time.svelte';
 	import StateBadge from '../common/StateBadge.svelte';
 	import CommunityActions from '../../../routes/(detail)/community/[uid]/CommunityActions.svelte';
 	import { useGetAdminCommunity } from '$lib/hooks/communities';
 
-	export let isAdmin = false;
-	export let title = '';
-	export let description = '';
+	export let isAdmin: Boolean = false;
+	export let title: string = '';
+	export let description: string = '';
 	export let state = {};
-	export let uid;
+	export let uid: string;
 
 	let community = useGetAdminCommunity(uid);
 	$: cmn = $community.data;

--- a/src/routes/(detail)/community/[uid]/CommunityView.svelte
+++ b/src/routes/(detail)/community/[uid]/CommunityView.svelte
@@ -23,6 +23,7 @@
 	import CommunityIssued from './CommunityIssued.svelte';
 	import TabHeader from '$lib/components/common/TabHeader.svelte';
 	import CommunityActions from './CommunityActions.svelte';
+	import CommunityHeader from '$lib/components/communities/CommunityHeader.svelte';
 
 	export let uid: string = '';
 
@@ -46,23 +47,7 @@
 			<div class="w-full max-w-screen-lg">
 				<CommunityBanner image={cmn?.image} />
 				<div class="px-4 pb-4 pt-3">
-					<div class="flex items-center justify-between">
-						<div>
-							<StateBadge data={sts} />
-							<span class="ms-2 text-xs">
-								Last update <Time relative={true} timestamp={cmn?.createdUTC.replace('T', ' ')} />
-							</span>
-						</div>
-						<CommunityActions community={cmn} />
-					</div>
-
-					<h6 class="mb-2 mt-2 text-3xl font-bold text-gray-900 dark:text-white">
-						{cmn?.name}
-					</h6>
-					<p class="mb-2 text-base text-gray-600 dark:text-gray-400">
-						{cmn?.description}
-					</p>
-          &nbsp;
+					<CommunityHeader isAdmin={false} {uid} state={sts} title={cmn?.name} description={cmn?.description} />
 					<Tabs
 						style="underline"
 						contentClass="p-4 bg-transparent rounded-lg dark:bg-gray-800 mt-4"

--- a/src/routes/(detail)/community/[uid]/CommunityView.svelte
+++ b/src/routes/(detail)/community/[uid]/CommunityView.svelte
@@ -1,20 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { useGetCommunity } from '$lib/hooks/communities';
 	import { findState } from '$lib/types/states';
-	import type { Community } from '$lib/types';
 	//
-	import Time from 'svelte-time';
-	import { Dropdown, DropdownItem, Tabs, TabItem } from 'flowbite-svelte';
-	import { Badge, Avatar, Button, Img } from 'flowbite-svelte';
-	import {
-		EnvelopeSolid,
-		EditSolid,
-		ShareNodesSolid,
-		DotsVerticalOutline
-	} from 'flowbite-svelte-icons';
+	import { Tabs, TabItem } from 'flowbite-svelte';
+	
 	import { H1, ErrorOnFetch } from '$lib/components';
-	import StateBadge from '$lib/components/common/StateBadge.svelte';
 	import Breadcrumbs from '$lib/components/common/Breadcrumbs.svelte';
 	import CommunityBanner from '$lib/components/communities/CommunityBanner.svelte';
 	import CredentialsList from '$lib/components/credentials/CredentialsList.svelte';
@@ -22,7 +12,6 @@
 	import CommunityMembers from './CommunityMembers.svelte';
 	import CommunityIssued from './CommunityIssued.svelte';
 	import TabHeader from '$lib/components/common/TabHeader.svelte';
-	import CommunityActions from './CommunityActions.svelte';
 	import CommunityHeader from '$lib/components/communities/CommunityHeader.svelte';
 
 	export let uid: string = '';

--- a/src/routes/(detail)/community/[uid]/CommunityView.svelte
+++ b/src/routes/(detail)/community/[uid]/CommunityView.svelte
@@ -1,105 +1,96 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-  import { useGetCommunity } from "$lib/hooks/communities";
-  import { findState } from '$lib/types/states';
-  import type { Community } from "$lib/types";
-  // 
-  import Time from 'svelte-time';
-  import { Dropdown, DropdownItem, Tabs, TabItem } from 'flowbite-svelte';
-  import { Badge, Avatar, Button, Img } from 'flowbite-svelte';
-  import { EnvelopeSolid, EditSolid, ShareNodesSolid,DotsVerticalOutline } from "flowbite-svelte-icons";
-  import { H1, ErrorOnFetch } from "$lib/components";
-  import StateBadge from '$lib/components/common/StateBadge.svelte';
-  import Breadcrumbs from "$lib/components/common/Breadcrumbs.svelte";
-	import CommunityBanner from "$lib/components/communities/CommunityBanner.svelte";
-  import CredentialsList from "$lib/components/credentials/CredentialsList.svelte";
-  import CommunityClaimables from "./CommunityClaimables.svelte";
-  import CommunityMembers from "./CommunityMembers.svelte";
-  import CommunityIssued from "./CommunityIssued.svelte";
-  import TabHeader from "$lib/components/common/TabHeader.svelte";
-  import CommunityActions from "./CommunityActions.svelte";
+	import { onMount } from 'svelte';
+	import { useGetCommunity } from '$lib/hooks/communities';
+	import { findState } from '$lib/types/states';
+	import type { Community } from '$lib/types';
+	//
+	import Time from 'svelte-time';
+	import { Dropdown, DropdownItem, Tabs, TabItem } from 'flowbite-svelte';
+	import { Badge, Avatar, Button, Img } from 'flowbite-svelte';
+	import {
+		EnvelopeSolid,
+		EditSolid,
+		ShareNodesSolid,
+		DotsVerticalOutline
+	} from 'flowbite-svelte-icons';
+	import { H1, ErrorOnFetch } from '$lib/components';
+	import StateBadge from '$lib/components/common/StateBadge.svelte';
+	import Breadcrumbs from '$lib/components/common/Breadcrumbs.svelte';
+	import CommunityBanner from '$lib/components/communities/CommunityBanner.svelte';
+	import CredentialsList from '$lib/components/credentials/CredentialsList.svelte';
+	import CommunityClaimables from './CommunityClaimables.svelte';
+	import CommunityMembers from './CommunityMembers.svelte';
+	import CommunityIssued from './CommunityIssued.svelte';
+	import TabHeader from '$lib/components/common/TabHeader.svelte';
+	import CommunityActions from './CommunityActions.svelte';
 
-  export let uid: string = "";
+	export let uid: string = '';
 
-  let joined = true, sts = 0;
-  let community = useGetCommunity(uid!);
+	let joined = true,
+		sts = 0;
+	let community = useGetCommunity(uid!);
 
-  $: cmn = $community.data;
-  $: sts = findState((cmn?.state === 'INITIAL') ? 'Revision' : (cmn?.state || '-'));
+	$: cmn = $community.data;
+	$: sts = findState(cmn?.state === 'INITIAL' ? 'Revision' : cmn?.state || '-');
 </script>
 
 <div class="p-4">
-  <Breadcrumbs label={$community.data?.name || '?'}/>
+	<Breadcrumbs label={$community.data?.name || '?'} />
 
-  <div>
-    {#if $community.isLoading}
-      <span>Loading...</span>
-    {:else if $community.isError}
-      <ErrorOnFetch 
-        description="My community"
-        error={$community.error} 
-      />
-    {:else}
-      <div class="w-full max-w-screen-lg">
-        <CommunityBanner image={cmn?.image} />
-      
-        <div class="px-4 pt-3 pb-4">
-          <div class="flex justify-between items-center">
-            <div>
-              <StateBadge data={sts} /> 
-              <span class="text-xs ms-2">
-                Last update <Time relative={true} timestamp={cmn?.createdUTC.replace('T',' ')} />
-              </span>
-            </div>
-            <CommunityActions 
-              community={cmn} 
-            />
-          </div>
-        
-          <h6 class="mt-2 mb-2 text-3xl font-bold text-gray-900 dark:text-white">
-            {cmn?.name}
-          </h6>
-          <p class="mb-2 text-base text-gray-600 dark:text-gray-400">
-            {cmn?.description}                                              
-          </p>
+	<div>
+		{#if $community.isLoading}
+			<span>Loading...</span>
+		{:else if $community.isError}
+			<ErrorOnFetch description="My community" error={$community.error} />
+		{:else}
+			<div class="w-full max-w-screen-lg">
+				<CommunityBanner image={cmn?.image} />
+				<div class="px-4 pb-4 pt-3">
+					<div class="flex items-center justify-between">
+						<div>
+							<StateBadge data={sts} />
+							<span class="ms-2 text-xs">
+								Last update <Time relative={true} timestamp={cmn?.createdUTC.replace('T', ' ')} />
+							</span>
+						</div>
+						<CommunityActions community={cmn} />
+					</div>
 
-          <Tabs style="underline" 
-            contentClass="p-4 bg-transparent rounded-lg dark:bg-gray-800 mt-4"
-            defaultClass="flex flex-wrap items-end justify-center space-x-8 rtl:space-x-reverse">
-            <TabItem open class="">
-              <TabHeader slot="title"
-                label="Claim & Earn"
-                count={ cmn?.countClaimables }
-              />
-              <div>
-                <CommunityClaimables communityUid={uid} />
-              </div>
-            </TabItem>
+					<h6 class="mb-2 mt-2 text-3xl font-bold text-gray-900 dark:text-white">
+						{cmn?.name}
+					</h6>
+					<p class="mb-2 text-base text-gray-600 dark:text-gray-400">
+						{cmn?.description}
+					</p>
+          &nbsp;
+					<Tabs
+						style="underline"
+						contentClass="p-4 bg-transparent rounded-lg dark:bg-gray-800 mt-4"
+						defaultClass="flex flex-wrap items-end justify-center space-x-8 rtl:space-x-reverse"
+					>
+						<TabItem open class="">
+							<TabHeader slot="title" label="Claim & Earn" count={cmn?.countClaimables} />
+							<div>
+								<CommunityClaimables communityUid={uid} />
+							</div>
+						</TabItem>
 
-            <TabItem class="">
-              <TabHeader slot="title"
-                label="Issued"
-                count={ cmn?.countCredentials }
-              />
-              <div>
-                <CommunityIssued communityUid={uid} />
-              </div>
-            </TabItem>
+						<TabItem class="">
+							<TabHeader slot="title" label="Issued" count={cmn?.countCredentials} />
+							<div>
+								<CommunityIssued communityUid={uid} />
+							</div>
+						</TabItem>
 
-            <TabItem class="">
-              <TabHeader slot="title"
-                label="Members"
-                count={ cmn?.countMembers }
-              />
-              <div class="">
-                <CommunityMembers 
-                  communityUid={uid}         
-                />
-              </div>
-            </TabItem>
-          </Tabs>
-        </div>
-      </div>  
-    {/if}
-  </div>
+						<TabItem class="">
+							<TabHeader slot="title" label="Members" count={cmn?.countMembers} />
+							<div class="">
+								<CommunityMembers communityUid={uid} />
+							</div>
+						</TabItem>
+					</Tabs>
+				</div>
+			</div>
+		{/if}
+	</div>
 </div>

--- a/src/routes/(detail)/community/admin/[uid]/+page.svelte
+++ b/src/routes/(detail)/community/admin/[uid]/+page.svelte
@@ -16,7 +16,7 @@
   description="" 
 />
 
-<div>
+<div class="p-4">
   {#key refreshOn}
     <CommunityAdmin uid={data.uid} />
   {/key}

--- a/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
+++ b/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div class="p-4">
-	<Breadcrumb class="flex mt-8 mb-8 ms-2">
+	<Breadcrumb class="mb-8 ms-2 mt-8 flex">
 		<BreadcrumbItem home href="/home">General</BreadcrumbItem>
 		<BreadcrumbItem>Admin communities</BreadcrumbItem>
 		<BreadcrumbItem>{$community.data?.name || '?'}</BreadcrumbItem>
@@ -43,7 +43,8 @@
 		{:else}
 			<div class="w-full max-w-screen-lg">
 				<CommunityBanner image={$community.data?.image} />
-				<div class="">
+				<div class="px-4 pb-4 pt-3">
+					<!-- ESTANDARIZAR DESDE -->
 					<div class="flex items-center justify-between">
 						<div>
 							<StateBadge data={state} />
@@ -55,14 +56,14 @@
 							</span>
 						</div>
 					</div>
-
-					<h6 class="mb-2 mt-2 text-3xl font-bold text-gray-900 dark:text-white">
+					<h6 class="mb-2 mt-2 text-3xl font-bold text-gray-900 dark:text-white pt-1">
 						{$community.data?.name}
 					</h6>
 					<p class="mb-2 text-base text-gray-600 dark:text-gray-400">
 						{$community.data?.description}
 					</p>
-
+					&nbsp;
+					<!-- ESTANDARIZAR HASTA -->
 					<Tabs
 						style="underline"
 						contentClass="pt-14 pr-5 pb-4 pl-7 bg-transparent rounded-lg dark:bg-gray-800"

--- a/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
+++ b/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
@@ -28,8 +28,8 @@
 		'px-3 py-1.5 inline-block text-sm font-medium text-center disabled:cursor-not-allowed border-b-2 border-transparent hover:text-gray-600 hover:border-gray-300 dark:hover:text-gray-300 text-gray-500 dark:text-gray-400';
 </script>
 
-<div>
-	<Breadcrumb class="pl-6 pt-8">
+<div class="p-4">
+	<Breadcrumb class="flex mt-8 mb-8 ms-2">
 		<BreadcrumbItem home href="/home">General</BreadcrumbItem>
 		<BreadcrumbItem>Admin communities</BreadcrumbItem>
 		<BreadcrumbItem>{$community.data?.name || '?'}</BreadcrumbItem>
@@ -43,7 +43,6 @@
 		{:else}
 			<div class="w-full max-w-screen-lg">
 				<CommunityBanner image={$community.data?.image} />
-
 				<div class="">
 					<div class="flex items-center justify-between">
 						<div>

--- a/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
+++ b/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
@@ -2,14 +2,13 @@
 	import { Breadcrumb, BreadcrumbItem, P, TabItem, Tabs } from 'flowbite-svelte';
 	import { H1, ErrorOnFetch, StateBadge } from '$lib/components';
 	import { useGetAdminCommunity } from '$lib/hooks/communities';
-	import type { Community } from '$lib/types';
 	import Credentials from './Credentials.svelte';
 	import Members from './Members.svelte';
 	import TabHeader from '$lib/components/common/TabHeader.svelte';
-	import Time from 'svelte-time/Time.svelte';
 	import CommunityBanner from '$lib/components/communities/CommunityBanner.svelte';
 	import General from './General.svelte';
 	import { findState } from '$lib/types/states';
+	import CommunityHeader from '$lib/components/communities/CommunityHeader.svelte';
 
 	export let uid: string;
 	let community = useGetAdminCommunity(uid);
@@ -44,26 +43,7 @@
 			<div class="w-full max-w-screen-lg">
 				<CommunityBanner image={$community.data?.image} />
 				<div class="px-4 pb-4 pt-3">
-					<!-- ESTANDARIZAR DESDE -->
-					<div class="flex items-center justify-between">
-						<div>
-							<StateBadge data={state} />
-							<span class="ms-2 text-xs">
-								Last update <Time
-									relative={true}
-									timestamp={$community.data?.createdUTC.replace('T', ' ')}
-								/>
-							</span>
-						</div>
-					</div>
-					<h6 class="mb-2 mt-2 text-3xl font-bold text-gray-900 dark:text-white pt-1">
-						{$community.data?.name}
-					</h6>
-					<p class="mb-2 text-base text-gray-600 dark:text-gray-400">
-						{$community.data?.description}
-					</p>
-					&nbsp;
-					<!-- ESTANDARIZAR HASTA -->
+					<CommunityHeader isAdmin={true} {uid} {state} title={$community.data?.name} description={$community.data?.description} />
 					<Tabs
 						style="underline"
 						contentClass="pt-14 pr-5 pb-4 pl-7 bg-transparent rounded-lg dark:bg-gray-800"

--- a/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
+++ b/src/routes/(detail)/community/admin/[uid]/CommunityAdmin.svelte
@@ -49,7 +49,7 @@
 						contentClass="pt-14 pr-5 pb-4 pl-7 bg-transparent rounded-lg dark:bg-gray-800"
 						defaultClass="flex flex-wrap items-end justify-center space-x-2 lg:space-x-10 rtl:space-x-reverse"
 					>
-						<TabItem open {activeClasses} {inactiveClasses}>
+						<TabItem open ><!-- {activeClasses} {inactiveClasses} -->
 							<TabHeader slot="title" label="General" showCount={false} />
 							{#if $community.data}
 								<div>
@@ -58,14 +58,14 @@
 							{/if}
 						</TabItem>
 
-						<TabItem {activeClasses} {inactiveClasses}>
+						<TabItem>
 							<TabHeader slot="title" label="Credentials Campaigns" count={plans.length || 0} />
 							<div>
 								<Credentials {community} />
 							</div>
 						</TabItem>
 
-						<TabItem {activeClasses} {inactiveClasses}>
+						<TabItem>
 							<TabHeader slot="title" label="Members" count={$community.data?.countMembers} />
 							<div class="">
 								<Members communityUid={uid} />


### PR DESCRIPTION
# Community Header ( styling & componentization )

## Fix summary

Header componentizado, ubicado específicamente en $lib/components/communities/CommunityHeader.svelte.

Habían clases customizadas para los tabs de admin (CommunityAdmin.svelte) que hacían que no tuvieran un espaciado prolijo como lo son en el default (CommunityView.svelte). Fueron quitadas para lograr mayor similitud.

Se agregaron algunas clases para ajustar estilos de padding y margin.

## Previews
### Community Admin header preview
![admin1](https://github.com/user-attachments/assets/72a3d2f9-c85f-4c45-8bde-8d9bcd5a592c)

### Default Community header preview
![default1](https://github.com/user-attachments/assets/77097027-8df5-4457-9998-ef61325657fd)
